### PR TITLE
feat(manage-lyrics): 모바일 전용 페인트 에디터 및 UI 다이얼로그 개편

### DIFF
--- a/src/features/manage-lyrics/ui/LyricRow.tsx
+++ b/src/features/manage-lyrics/ui/LyricRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Paintbrush, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { LyricLine } from "@/shared/types/lyrics";
@@ -12,6 +12,8 @@ import { cn } from "@/shared/utils/utils";
 
 import { useAdminEditorContext } from "./AdminEditorContext";
 import { ExtraSegmentEditor } from "./ExtraSegmentEditor";
+import { MobilePaintEditor } from "./MobilePaintEditor";
+import { RawTextEditor } from "./RawTextEditor";
 
 interface LyricRowProps {
   /** 이 행이 표시할 가사 데이터 */
@@ -39,17 +41,22 @@ function LyricRowInner({ line, index, isCurrent, isError }: LyricRowProps) {
     addExtraLine,
     deleteLine,
     handleMouseUpText,
-    handleEditRawText,
     lastAddedTimeRef,
     setCurrentIndex,
   } = useAdminEditorContext();
 
   /**
-   * 타임스킬프 입력 로컈 상태
+   * 타임스킬프 입력 로컬 상태
    * blur / Enter 시에만 updateLine을 호출하여 타이핑 중 방해를 없애줍니다.
    * line.startTime이 외부에서 바뀌면 부모(LyricRow)의 key가 변경되어 여기서 새로 마운트됩니다.
    */
   const [localTime, setLocalTime] = useState(formatTime(line.startTime));
+
+  /** 모바일 페인트 에디터 다이얼로그 오픈 상태 */
+  const [isMobileEditorOpen, setIsMobileEditorOpen] = useState(false);
+
+  /** 원시 텍스트(Prompt 대체) 에디터 다이얼로그 오픈 상태 */
+  const [isRawEditorOpen, setIsRawEditorOpen] = useState(false);
 
   const commitTime = () => {
     const parsed = parseTime(localTime);
@@ -61,183 +68,209 @@ function LyricRowInner({ line, index, isCurrent, isError }: LyricRowProps) {
   };
 
   return (
-    <div
-      className={cn(
-        "grid items-center gap-2 rounded-md border p-2 transition-all",
-        // lg+: 기존 4컬럼 한 줄 | lg 미만: Time·Extra·Action 1행 + Lyrics 2행
-        "grid-cols-[100px_1fr_220px] lg:grid-cols-[100px_1fr_60px_220px]",
-        isCurrent
-          ? "border-primary/50 bg-accent/50 ring-primary/20 ring-1"
-          : "border-border/50 bg-background",
-        isError && "border-destructive/50 bg-destructive/5",
-      )}
-      onClick={() => setCurrentIndex(index)}
-    >
-      {/* 타임스킬프 입력: 로컈 상태로 관리하여 타이핑 중 방해 없음 */}
-      <Input
-        type="text"
-        value={localTime}
-        onChange={(e) => setLocalTime(e.target.value)}
-        onBlur={commitTime}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.currentTarget.blur();
-          }
-        }}
-        className="border-input bg-muted/30 focus-visible:ring-primary/30 h-8 font-mono text-xs"
-      />
-
-      {/* isExtra 체크박스 (lg 미만에서 1행에 표시) */}
-      <div className="flex justify-center lg:hidden">
-        <Checkbox
-          checked={line.isExtra}
-          onCheckedChange={(c) => updateLine(index, { isExtra: !!c })}
-          className="data-[state=checked]:bg-qwer-e data-[state=checked]:border-qwer-e"
-        />
-      </div>
-
-      {/* Action 버튼 그룹 (lg 미만에서 1행에 표시) */}
-      <div className="flex justify-end gap-1 lg:hidden">
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-muted-foreground hover:text-foreground hover:bg-accent h-7 w-7"
-          title="텍스트 수정"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleEditRawText(index);
-          }}
-        >
-          <Pencil size={12} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="hover:bg-primary/10 hover:text-primary h-7 w-7"
-          title="SYNC"
-          onClick={(e) => {
-            e.stopPropagation();
-            captureTime(index);
-          }}
-        >
-          <RefreshCw size={12} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-qwer-e/70 hover:text-qwer-e hover:bg-qwer-e/10 h-7 w-7"
-          title="추임새 추가"
-          onClick={(e) => {
-            e.stopPropagation();
-            const t = addExtraLine(index);
-            lastAddedTimeRef.current = t;
-          }}
-        >
-          <Plus size={12} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-destructive/70 hover:text-destructive hover:bg-destructive/10 h-7 w-7"
-          title="삭제"
-          onClick={(e) => {
-            e.stopPropagation();
-            deleteLine(index);
-          }}
-        >
-          <Trash2 size={12} />
-        </Button>
-      </div>
-
-      {/* 가사 영역: lg 미만에서 2행 전체 너비, lg+에서 원래 위치 */}
-      <div className="col-span-3 lg:col-span-1">
-        {line.isExtra ? (
-          <ExtraSegmentEditor line={line} lineIndex={index} />
-        ) : (
-          <div
-            className="border-input bg-muted/20 flex min-h-8 items-center overflow-x-auto rounded border px-2 text-sm"
-            onMouseUp={(e) => handleMouseUpText(e, index)}
-          >
-            {line.segments?.map((seg, sIdx) => (
-              <span
-                key={sIdx}
-                data-line={index}
-                data-seg={sIdx}
-                className={cn(
-                  "selection:bg-primary/20 cursor-text whitespace-pre",
-                  seg.isCheer && "text-qwer-r font-bold",
-                  seg.isEcho && "text-qwer-r decoration-qwer-r/50 underline underline-offset-4",
-                )}
-              >
-                {seg.text}
-              </span>
-            ))}
-          </div>
+    <>
+      <div
+        className={cn(
+          "grid items-center gap-2 rounded-md border p-2 transition-all",
+          // lg+: 기존 4컬럼 한 줄 | lg 미만: Time·Extra·Action 1행 + Lyrics 2행
+          "grid-cols-[100px_1fr_220px] lg:grid-cols-[100px_1fr_60px_220px]",
+          isCurrent
+            ? "border-primary/50 bg-accent/50 ring-primary/20 ring-1"
+            : "border-border/50 bg-background",
+          isError && "border-destructive/50 bg-destructive/5",
         )}
-      </div>
-
-      {/* isExtra 체크박스 (lg+ 전용, 기존 위치 유지) */}
-      <div className="hidden justify-center lg:flex">
-        <Checkbox
-          checked={line.isExtra}
-          onCheckedChange={(c) => updateLine(index, { isExtra: !!c })}
-          className="data-[state=checked]:bg-qwer-e data-[state=checked]:border-qwer-e"
+        onClick={() => setCurrentIndex(index)}
+      >
+        {/* 타임스킬프 입력: 로컬 상태로 관리하여 타이핑 중 방해 없음 */}
+        <Input
+          type="text"
+          value={localTime}
+          onChange={(e) => setLocalTime(e.target.value)}
+          onBlur={commitTime}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.currentTarget.blur();
+            }
+          }}
+          className="border-input bg-muted/30 focus-visible:ring-primary/30 h-8 font-mono text-xs"
         />
-      </div>
 
-      {/* Action 버튼 그룹 (lg+ 전용, 기존 위치 유지) */}
-      <div className="hidden justify-center gap-1 lg:flex">
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-muted-foreground hover:text-foreground hover:bg-accent h-8 w-8"
-          title="텍스트 수정"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleEditRawText(index);
-          }}
-        >
-          <Pencil size={14} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="hover:bg-primary/10 hover:text-primary h-8 w-8"
-          title="타임스탬프 동기화 (SYNC)"
-          onClick={(e) => {
-            e.stopPropagation();
-            captureTime(index);
-          }}
-        >
-          <RefreshCw size={14} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-qwer-e/70 hover:text-qwer-e hover:bg-qwer-e/10 h-8 w-8"
-          title="아래에 추임새 행 추가"
-          onClick={(e) => {
-            e.stopPropagation();
-            const addedTime = addExtraLine(index);
-            lastAddedTimeRef.current = addedTime;
-          }}
-        >
-          <Plus size={14} />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="text-destructive/70 hover:text-destructive hover:bg-destructive/10 h-8 w-8"
-          title="현재 행 삭제"
-          onClick={(e) => {
-            e.stopPropagation();
-            deleteLine(index);
-          }}
-        >
-          <Trash2 size={14} />
-        </Button>
+        {/* isExtra 체크박스 (lg 미만에서 1행에 표시) */}
+        <div className="flex justify-center lg:hidden">
+          <Checkbox
+            checked={line.isExtra}
+            onCheckedChange={(c) => updateLine(index, { isExtra: !!c })}
+            className="data-[state=checked]:bg-qwer-e data-[state=checked]:border-qwer-e"
+          />
+        </div>
+
+        {/* Action 버튼 그룹 (lg 미만에서 1행에 표시) */}
+        <div className="flex justify-end gap-1 lg:hidden">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-muted-foreground hover:text-foreground hover:bg-accent h-7 w-7"
+            title="텍스트 수정"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsRawEditorOpen(true);
+            }}
+          >
+            <Pencil size={12} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-muted-foreground hover:text-foreground hover:bg-accent h-7 w-7"
+            title="가사 속성 칠하기 (페인트)"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsMobileEditorOpen(true);
+            }}
+          >
+            <Paintbrush size={12} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="hover:bg-primary/10 hover:text-primary h-7 w-7"
+            title="SYNC"
+            onClick={(e) => {
+              e.stopPropagation();
+              captureTime(index);
+            }}
+          >
+            <RefreshCw size={12} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-qwer-e/70 hover:text-qwer-e hover:bg-qwer-e/10 h-7 w-7"
+            title="추임새 추가"
+            onClick={(e) => {
+              e.stopPropagation();
+              const t = addExtraLine(index);
+              lastAddedTimeRef.current = t;
+            }}
+          >
+            <Plus size={12} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-destructive/70 hover:text-destructive hover:bg-destructive/10 h-7 w-7"
+            title="삭제"
+            onClick={(e) => {
+              e.stopPropagation();
+              deleteLine(index);
+            }}
+          >
+            <Trash2 size={12} />
+          </Button>
+        </div>
+
+        {/* 가사 영역: lg 미만에서 2행 전체 너비, lg+에서 원래 위치 */}
+        <div className="col-span-3 lg:col-span-1">
+          {line.isExtra ? (
+            <ExtraSegmentEditor line={line} lineIndex={index} />
+          ) : (
+            <div
+              className="border-input bg-muted/20 flex min-h-8 items-center overflow-x-auto rounded border px-2 text-sm"
+              onMouseUp={(e) => handleMouseUpText(e, index)}
+            >
+              {line.segments?.map((seg, sIdx) => (
+                <span
+                  key={sIdx}
+                  data-line={index}
+                  data-seg={sIdx}
+                  className={cn(
+                    "selection:bg-primary/20 cursor-text whitespace-pre",
+                    seg.isCheer && "text-qwer-r font-bold",
+                    seg.isEcho && "text-qwer-r decoration-qwer-r/50 underline underline-offset-4",
+                  )}
+                >
+                  {seg.text}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* isExtra 체크박스 (lg+ 전용, 기존 위치 유지) */}
+        <div className="hidden justify-center lg:flex">
+          <Checkbox
+            checked={line.isExtra}
+            onCheckedChange={(c) => updateLine(index, { isExtra: !!c })}
+            className="data-[state=checked]:bg-qwer-e data-[state=checked]:border-qwer-e"
+          />
+        </div>
+
+        {/* Action 버튼 그룹 (lg+ 전용, 기존 위치 유지) */}
+        <div className="hidden justify-center gap-1 lg:flex">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-muted-foreground hover:text-foreground hover:bg-accent h-8 w-8"
+            title="텍스트 수정"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsRawEditorOpen(true);
+            }}
+          >
+            <Pencil size={14} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="hover:bg-primary/10 hover:text-primary h-8 w-8"
+            title="타임스탬프 동기화 (SYNC)"
+            onClick={(e) => {
+              e.stopPropagation();
+              captureTime(index);
+            }}
+          >
+            <RefreshCw size={14} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-qwer-e/70 hover:text-qwer-e hover:bg-qwer-e/10 h-8 w-8"
+            title="아래에 추임새 행 추가"
+            onClick={(e) => {
+              e.stopPropagation();
+              const addedTime = addExtraLine(index);
+              lastAddedTimeRef.current = addedTime;
+            }}
+          >
+            <Plus size={14} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-destructive/70 hover:text-destructive hover:bg-destructive/10 h-8 w-8"
+            title="현재 행 삭제"
+            onClick={(e) => {
+              e.stopPropagation();
+              deleteLine(index);
+            }}
+          >
+            <Trash2 size={14} />
+          </Button>
+        </div>
       </div>
-    </div>
+      <MobilePaintEditor
+        isOpen={isMobileEditorOpen}
+        onClose={() => setIsMobileEditorOpen(false)}
+        line={line}
+        lineIndex={index}
+      />
+      <RawTextEditor
+        isOpen={isRawEditorOpen}
+        onClose={() => setIsRawEditorOpen(false)}
+        line={line}
+        lineIndex={index}
+      />
+    </>
   );
 }
 

--- a/src/features/manage-lyrics/ui/MobilePaintEditor.tsx
+++ b/src/features/manage-lyrics/ui/MobilePaintEditor.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { LyricLine, LyricSegment } from "@/shared/types/lyrics";
+import { Button } from "@/shared/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shared/ui/dialog";
+import { cn } from "@/shared/utils/utils";
+
+import { useAdminEditorContext } from "./AdminEditorContext";
+
+type PaintMode = "normal" | "cheer" | "echo";
+
+interface CharItem {
+  id: string;
+  char: string;
+  mode: PaintMode;
+  startTimeOffset?: number;
+}
+
+interface MobilePaintEditorProps {
+  line: LyricLine;
+  lineIndex: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function MobilePaintEditor({ line, lineIndex, isOpen, onClose }: MobilePaintEditorProps) {
+  const { updateLine } = useAdminEditorContext();
+  const [chars, setChars] = useState<CharItem[]>([]);
+  const [currentMode, setCurrentMode] = useState<PaintMode>("normal");
+
+  // prop 변경 시 상태를 렌더링 중에 동기화 (You Might Not Need an Effect 패턴)
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [prevLine, setPrevLine] = useState(line);
+
+  if (isOpen !== prevIsOpen || line !== prevLine) {
+    setPrevIsOpen(isOpen);
+    setPrevLine(line);
+
+    if (isOpen) {
+      const newChars: CharItem[] = [];
+      let charId = 0;
+
+      for (const seg of line.segments || []) {
+        const mode: PaintMode = seg.isEcho ? "echo" : seg.isCheer ? "cheer" : "normal";
+        for (let i = 0; i < seg.text.length; i++) {
+          newChars.push({
+            id: `char-${charId++}`,
+            char: seg.text[i],
+            mode,
+            // 첫 번째 글자에만 기존의 startTimeOffset을 유지
+            startTimeOffset: i === 0 ? seg.startTimeOffset : undefined,
+          });
+        }
+      }
+      setChars(newChars);
+      setCurrentMode("normal"); // 초기 모드
+    }
+  }
+
+  const isPainting = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleSave = () => {
+    const newSegments: LyricSegment[] = [];
+    let currentSeg: LyricSegment | null = null;
+    let lastMode: PaintMode | null = null;
+
+    for (const item of chars) {
+      // 모드가 바뀌거나, 기존 세그먼트의 시작점(startTimeOffset)이 있는 글자라면 강제로 세그먼트를 분리
+      if (!currentSeg || lastMode !== item.mode || item.startTimeOffset !== undefined) {
+        if (currentSeg) newSegments.push(currentSeg);
+        currentSeg = {
+          text: item.char,
+          isCheer: item.mode === "cheer",
+          isEcho: item.mode === "echo",
+        };
+        if (item.startTimeOffset !== undefined) {
+          currentSeg.startTimeOffset = item.startTimeOffset;
+        }
+        lastMode = item.mode;
+      } else {
+        currentSeg.text += item.char;
+      }
+    }
+    if (currentSeg) newSegments.push(currentSeg);
+
+    updateLine(lineIndex, { segments: newSegments });
+    onClose();
+  };
+
+  const paintChar = (index: number) => {
+    setChars((prev) => {
+      const next = [...prev];
+      if (next[index].mode !== currentMode) {
+        next[index] = { ...next[index], mode: currentMode };
+      }
+      return next;
+    });
+  };
+
+  // 터치/마우스 이벤트 처리 (스와이프/드래그 페인팅 지원)
+  const handlePointerDown = (index: number) => {
+    isPainting.current = true;
+    paintChar(index);
+  };
+
+  const handlePointerUp = () => {
+    isPainting.current = false;
+  };
+
+  // 터치 이동 시 좌표에 해당하는 요소를 찾아서 페인트
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isPainting.current) return;
+    const touch = e.touches[0];
+    const el = document.elementFromPoint(touch.clientX, touch.clientY);
+    if (el && el.hasAttribute("data-char-idx")) {
+      const idx = parseInt(el.getAttribute("data-char-idx")!, 10);
+      if (!isNaN(idx)) {
+        paintChar(idx);
+      }
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        className="flex max-h-[80vh] flex-col overflow-hidden sm:max-w-md"
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      >
+        <DialogHeader>
+          <DialogTitle>가사 편집 (페인트 모드)</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto py-4">
+          {/* 모드 선택 팔레트 */}
+          <div className="flex justify-center gap-2">
+            <Button
+              variant={currentMode === "normal" ? "default" : "outline"}
+              onClick={() => setCurrentMode("normal")}
+              className="flex-1"
+            >
+              기본
+            </Button>
+            <Button
+              variant={currentMode === "cheer" ? "default" : "outline"}
+              onClick={() => setCurrentMode("cheer")}
+              className={cn(
+                "flex-1",
+                currentMode === "cheer" && "bg-qwer-e text-qwer-e-foreground hover:bg-qwer-e/90",
+              )}
+            >
+              응원법
+            </Button>
+            <Button
+              variant={currentMode === "echo" ? "default" : "outline"}
+              onClick={() => setCurrentMode("echo")}
+              className={cn(
+                "flex-1",
+                currentMode === "echo" && "bg-qwer-r text-qwer-r-foreground hover:bg-qwer-r/90",
+              )}
+            >
+              에코
+            </Button>
+          </div>
+
+          {/* 가사 칠하기 영역 */}
+          <div
+            ref={containerRef}
+            className="border-input flex min-h-[150px] touch-none flex-wrap content-start items-start justify-center gap-2 rounded-lg border p-4 select-none"
+            onTouchMove={handleTouchMove}
+          >
+            {chars.map((item, idx) => (
+              <div
+                key={item.id}
+                data-char-idx={idx}
+                onPointerDown={() => handlePointerDown(idx)}
+                onPointerEnter={() => {
+                  // 마우스 드래그 지원
+                  if (isPainting.current) paintChar(idx);
+                }}
+                className={cn(
+                  "flex h-12 min-w-8 cursor-pointer items-center justify-center rounded-md text-2xl font-bold transition-colors select-none",
+                  item.char === " " ? "w-4 bg-transparent" : "bg-muted shadow-sm",
+                  item.mode === "cheer" && "bg-qwer-e/20 text-qwer-e ring-qwer-e ring-2",
+                  item.mode === "echo" &&
+                    "text-qwer-r ring-qwer-r decoration-qwer-r underline decoration-2 underline-offset-8 ring-2",
+                )}
+              >
+                {item.char}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-4">
+          <Button variant="outline" onClick={onClose}>
+            취소
+          </Button>
+          <Button onClick={handleSave}>완료</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/manage-lyrics/ui/RawTextEditor.tsx
+++ b/src/features/manage-lyrics/ui/RawTextEditor.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+
+import { LyricLine } from "@/shared/types/lyrics";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+
+import { useAdminEditorContext } from "./AdminEditorContext";
+
+interface RawTextEditorProps {
+  line: LyricLine;
+  lineIndex: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function RawTextEditor({ line, lineIndex, isOpen, onClose }: RawTextEditorProps) {
+  const { updateLine } = useAdminEditorContext();
+  const [text, setText] = useState("");
+
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [prevLine, setPrevLine] = useState(line);
+
+  if (isOpen !== prevIsOpen || line !== prevLine) {
+    setPrevIsOpen(isOpen);
+    setPrevLine(line);
+    if (isOpen) {
+      const rawText = (line.segments || []).map((s) => s.text).join("");
+      setText(rawText);
+    }
+  }
+
+  const handleSave = () => {
+    const rawText = (line.segments || []).map((s) => s.text).join("");
+    if (text !== rawText) {
+      updateLine(lineIndex, {
+        segments: [{ text, isCheer: false, isEcho: false }],
+      });
+    }
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>가사 텍스트 수정</DialogTitle>
+          <DialogDescription>
+            텍스트를 수정하면 해당 줄의 기존 응원법/에코 속성이 초기화됩니다.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4">
+          <Input
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="가사를 입력하세요"
+            autoFocus
+            className="text-lg"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            취소
+          </Button>
+          <Button onClick={handleSave}>저장</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/manage-lyrics/useAdminEditor.ts
+++ b/src/features/manage-lyrics/useAdminEditor.ts
@@ -209,24 +209,6 @@ export function useAdminEditor(song: AdminEditorSong) {
   );
 
   /**
-   * prompt를 통해 가사 행의 전체 텍스트를 수정합니다.
-   * 수정 시 기존 세그먼트 속성이 초기화됩니다.
-   */
-  const handleEditRawText = useCallback(
-    (index: number) => {
-      const rawText = lyrics[index].segments.map((s) => s.text).join("");
-      const newText = prompt(
-        "가사 텍스트를 수정하세요 (기존 세그먼트 속성이 초기화됩니다):",
-        rawText,
-      );
-      if (newText !== null && newText !== rawText) {
-        updateLine(index, { segments: [{ text: newText, isCheer: false, isEcho: false }] });
-      }
-    },
-    [lyrics, updateLine],
-  );
-
-  /**
    * 현재 재생 시간을 기준으로 특정 세그먼트의 startTimeOffset을 캡처합니다.
    * offset = 현재 재생 시간 - 라인의 startTime (최소 0)
    */
@@ -315,7 +297,6 @@ export function useAdminEditor(song: AdminEditorSong) {
     handleImportLrc,
     handleMouseUpText,
     handleSplitSegment,
-    handleEditRawText,
     captureSegmentOffset,
     updateSegment,
     applyRowOffset,


### PR DESCRIPTION
- 모바일 환경에서 발생하던 드래그 충돌 문제를 해결하기 위해, 글자 탭/스와이프 방식의 MobilePaintEditor 신규 도입
- 브라우저 기본 prompt()를 활용하던 기존의 가사 텍스트 수정 기능을 Shadcn UI 기반 RawTextEditor 다이얼로그 컴포넌트로 교체
- 전역 상태 관리 훅(useAdminEditor) 내부에 잔존하던 프롬프트 UI 호출부(handleEditRawText)를 제거하여 비즈니스 로직과 UI 관심사 분리
- LyricRow 모바일 액션 툴바에 페인트 편집 및 원시 텍스트 수정 버튼 배치